### PR TITLE
Add model selector, WebGPU capability check + tests, streaming chat UI, and build-to-docs for GH Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@huggingface/hub": "^2.4.0",
     "@mlc-ai/web-llm": "^0.2.79",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -23,10 +24,14 @@
     "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^4.7.0",
     "@webgpu/types": "^0.1.64",
+    "jsdom": "^26.1.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/CheckWebGPU.test.ts
+++ b/src/CheckWebGPU.test.ts
@@ -1,0 +1,47 @@
+import {isWebGPUok} from './CheckWebGPU.ts';
+import {describe, test, expect, vi} from 'vitest';
+
+describe('isWebGPUok', () => {
+    test('should return an error message if WebGPU is not supported', async () => {
+        // In jsdom, navigator.gpu is undefined, so this should fail.
+        const result = await isWebGPUok();
+        expect(result).toBe('WebGPU is NOT supported on this browser.');
+    });
+
+    test('should return an error message if adapter is not found', async () => {
+        // Mock navigator.gpu but make requestAdapter return null
+        vi.stubGlobal('navigator', {
+            gpu: {
+                requestAdapter: async () => null,
+            },
+        });
+
+        const result = await isWebGPUok();
+        expect(result).toBe('WebGPU Adapter not found.');
+    });
+
+    test('should return true if WebGPU is supported and working', async () => {
+        // A more complete mock of the WebGPU API
+        const mockDevice = {
+            createShaderModule: vi.fn(() => ({
+                getCompilationInfo: vi.fn().mockResolvedValue({
+                    messages: [],
+                }),
+            })),
+        };
+
+        const mockAdapter = {
+            requestDevice: async () => mockDevice,
+            features: new Set(['shader-f16']),
+        };
+
+        vi.stubGlobal('navigator', {
+            gpu: {
+                requestAdapter: async () => mockAdapter,
+            },
+        });
+
+        const result = await isWebGPUok();
+        expect(result).toBe(true);
+    });
+});

--- a/src/ModelSelector.tsx
+++ b/src/ModelSelector.tsx
@@ -1,0 +1,25 @@
+import {FormControl, InputLabel, Select, MenuItem} from "@mui/material";
+import {useTypedDispatch, useTypedSelector} from "./redux/store.ts";
+import {setSelectedModel} from "./redux/llmSlice.ts";
+
+export function ModelSelector() {
+    const dispatch = useTypedDispatch();
+    const {selectedModel, models} = useTypedSelector(state => state.llm);
+
+    return (
+        <FormControl fullWidth>
+            <InputLabel id="model-select-label">Model</InputLabel>
+            <Select
+                labelId="model-select-label"
+                id="model-select"
+                value={selectedModel}
+                label="Model"
+                onChange={(e) => dispatch(setSelectedModel(e.target.value))}
+            >
+                {models.map(model => (
+                    <MenuItem key={model.id} value={model.id}>{model.id}</MenuItem>
+                ))}
+            </Select>
+        </FormControl>
+    );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,1 @@
 export const DOWNLOADED_MODELS_KEY = 'downloaded_models';
-
-export const MODEL = 'Llama-3.2-1B-Instruct-q4f16_1-MLC';
-export const MODEL_SIZE_MB = 664;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const DOWNLOADED_MODELS_KEY = 'downloaded_models';
+
+export const MODEL = 'Llama-3.2-1B-Instruct-q4f16_1-MLC';
+export const MODEL_SIZE_MB = 664;

--- a/src/huggingface.ts
+++ b/src/huggingface.ts
@@ -1,0 +1,13 @@
+import {listModels} from "@huggingface/hub";
+
+export async function getCompatibleModels() {
+    const models = [];
+    for await (const model of listModels({
+        search: {
+            tags: ['gguf'],
+        }
+    })) {
+        models.push(model);
+    }
+    return models;
+}

--- a/src/redux/llmSlice.ts
+++ b/src/redux/llmSlice.ts
@@ -1,11 +1,14 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit'
 import type {ChatCompletionMessageParam} from "@mlc-ai/web-llm/lib/openai_api_protocols/chat_completion";
+import {ModelEntry} from "@huggingface/hub";
 
 type State = {
     messageHistory: ChatCompletionMessageParam[],
     criticalError: string | false,
     downloadStatus: string,
     isGenerating: boolean,
+    models: ModelEntry[],
+    selectedModel: string,
 }
 
 const initialState: State = {
@@ -13,6 +16,8 @@ const initialState: State = {
     criticalError: false,
     downloadStatus: 'waiting',
     isGenerating: false,
+    models: [],
+    selectedModel: '',
 }
 
 export const llmSlice = createSlice({
@@ -45,6 +50,15 @@ export const llmSlice = createSlice({
         },
         setIsGenerating: (state, action: PayloadAction<boolean>) => {
             state.isGenerating = action.payload;
+        },
+        setModels: (state, action: PayloadAction<ModelEntry[]>) => {
+            state.models = action.payload;
+            if (action.payload.length > 0 && !state.selectedModel) {
+                state.selectedModel = action.payload[0].id;
+            }
+        },
+        setSelectedModel: (state, action: PayloadAction<string>) => {
+            state.selectedModel = action.payload;
         }
     },
 })
@@ -55,6 +69,8 @@ export const {
     updateLastBotMessageContent,
     setDownloadStatus,
     setCriticalError,
-    setIsGenerating
+    setIsGenerating,
+    setModels,
+    setSelectedModel
 } = llmSlice.actions;
 export const llmReducer = llmSlice.reducer;

--- a/src/redux/llmSlice.ts
+++ b/src/redux/llmSlice.ts
@@ -1,27 +1,35 @@
-import {createSlice} from '@reduxjs/toolkit'
+import {createSlice, PayloadAction} from '@reduxjs/toolkit'
 import type {ChatCompletionMessageParam} from "@mlc-ai/web-llm/lib/openai_api_protocols/chat_completion";
 
 type State = {
     messageHistory: ChatCompletionMessageParam[],
     criticalError: string | false,
     downloadStatus: string,
+    isGenerating: boolean,
 }
 
 const initialState: State = {
     messageHistory: [],
     criticalError: false,
     downloadStatus: 'waiting',
+    isGenerating: false,
 }
 
 export const llmSlice = createSlice({
     name: 'llm',
     initialState,
     reducers: {
-        setMessageHistory: (
-            state,
-            {payload}: { payload: ChatCompletionMessageParam[] }
-        ) => {
-            state.messageHistory = payload;
+        addUserMessage: (state, action: PayloadAction<ChatCompletionMessageParam>) => {
+            state.messageHistory.push(action.payload);
+        },
+        addBotMessage: (state, action: PayloadAction<ChatCompletionMessageParam>) => {
+            state.messageHistory.push(action.payload);
+        },
+        updateLastBotMessageContent: (state, action: PayloadAction<string>) => {
+            const lastMessage = state.messageHistory[state.messageHistory.length - 1];
+            if (lastMessage && lastMessage.role === 'assistant') {
+                lastMessage.content += action.payload;
+            }
         },
         setDownloadStatus: (
             state,
@@ -35,8 +43,18 @@ export const llmSlice = createSlice({
         ) => {
             state.criticalError = payload;
         },
+        setIsGenerating: (state, action: PayloadAction<boolean>) => {
+            state.isGenerating = action.payload;
+        }
     },
 })
 
-export const {setMessageHistory, setDownloadStatus, setCriticalError} = llmSlice.actions;
+export const {
+    addUserMessage,
+    addBotMessage,
+    updateLastBotMessageContent,
+    setDownloadStatus,
+    setCriticalError,
+    setIsGenerating
+} = llmSlice.actions;
 export const llmReducer = llmSlice.reducer;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -8,4 +9,9 @@ export default defineConfig({
     },
     base: 'browser-llm',
     plugins: [react()],
+    test: {
+        globals: true,
+        environment: 'jsdom',
+        setupFiles: './src/test/setup.ts',
+    },
 })


### PR DESCRIPTION
Changes
UI/UX
Model selector (src/ModelSelector.tsx) populated from Hugging Face
Dark theme with MUI; responsive chat layout, message bubbles, send/stop controls
Markdown rendering for assistant messages
LLM integration
Lazy-load @mlc-ai/web-llm for faster initial page load
Streaming message updates and interrupt support
WebGPU readiness
Capability probe with shader compile check (src/CheckWebGPU.ts)
Vitest suite ensuring degraded cases return actionable messages
State management
Redux slice for messages, model selection, loading/generation states
Build/hosting
Vite build targets docs/ for GitHub Pages
Base path configured for pages hosting
Developer experience
Strict TypeScript config
Minimal test harness with jsdom